### PR TITLE
Add CLI file sorter

### DIFF
--- a/Python_Codes/File_sorter/File_sorter.py
+++ b/Python_Codes/File_sorter/File_sorter.py
@@ -1,7 +1,8 @@
-# Import necessary libraries
-import os, shutil
+"""Simple wrapper around :mod:`file_sorter_cli` for backward compatibility."""
+from pathlib import Path
+from file_sorter_cli import sort_files
 
-# --------------------------------------------------------------------------------------------------------
-# Code
-path = os.getcwd()
-print(f"Path: {path}")
+if __name__ == "__main__":
+    target = Path.cwd() / "FilesForSorting"
+    print(f"Sorting files in {target}")
+    sort_files(target)

--- a/Python_Codes/File_sorter/file_sorter_cli.py
+++ b/Python_Codes/File_sorter/file_sorter_cli.py
@@ -1,0 +1,43 @@
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+FOLDER_EXTENSIONS = {
+    'csv files': ['.csv'],
+    'image files': ['.jpg', '.jpeg', '.png', '.gif', '.bmp'],
+    'txt files': ['.txt'],
+    'xlsx files': ['.xlsx'],
+    'pdf files': ['.pdf']
+}
+
+
+def sort_files(base_path: Path) -> None:
+    """Sort files in *base_path* into folders based on their extension."""
+    if not base_path.is_dir():
+        raise ValueError(f"{base_path} is not a directory")
+
+    # Create target folders
+    for folder in FOLDER_EXTENSIONS:
+        (base_path / folder).mkdir(exist_ok=True)
+    (base_path / 'others').mkdir(exist_ok=True)
+
+    for item in base_path.iterdir():
+        if item.is_file():
+            target = base_path / 'others'
+            for folder, extensions in FOLDER_EXTENSIONS.items():
+                if item.suffix.lower() in extensions:
+                    target = base_path / folder
+                    break
+            shutil.move(str(item), target / item.name)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Sort files in a directory by extension")
+    parser.add_argument('path', nargs='?', default='.', help="Directory containing files to sort")
+    args = parser.parse_args(argv)
+    sort_files(Path(args.path))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- provide a `file_sorter_cli.py` module to sort files by extension
- update `File_sorter.py` to call the new sorter

## Testing
- `python3 -m py_compile Python_Codes/File_sorter/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6877617176748327b33aa54a4876ceb4